### PR TITLE
fix(cli) sanities options before passing to Github API

### DIFF
--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -92,7 +92,7 @@ DeploymentCommand.flags = {
   'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
   'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
   'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
-  'ref': flags.string({required: true, char: 'r', description: 'github ref,branch, or commit hash'}),
+  'ref': flags.string({required: true, description: 'github ref,branch, or commit hash'}),
   'env': flags.string({char: 'e', description: 'the deployment environment (production, qa, test, development etc)'}),
   'payload': flags.string({char: 'p', description: 'a json string that contains any extra context you need for your deployment'}),
   'auto-merge': flags.boolean({description: 'auto merge the default branch into pr (see gh deployments api for reference)', default: true, allowNo: true}),

--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -23,26 +23,33 @@ import {isString} from 'util';
 class DeploymentCommand extends Command {
   async run() {
     const {flags} = this.parse(DeploymentCommand);
-    const {repo, owner, token, ...rest} = flags;
+    const {
+      repo,
+      owner,
+      token,
+      env,
+      'auto-merge': autoMerge,
+      'required-contexts': requiredContexts,
+      'transient-environment': transientEnvironment,
+      ...rest
+    } = flags;
     const options = {
       ...rest,
-      environment: rest.env || rest.environment,
+      environment: env || rest.environment,
     };
 
-    if (options['auto-merge']) {
-      options.auto_merge = options['auto-merge'];
-    }
+    options.auto_merge = autoMerge;
 
-    if (options['required-contexts']) {
-      if (options['required-contexts'] === '[]') {
+    if (requiredContexts) {
+      if (requiredContexts === '[]') {
         options.required_contexts = [];
       } else {
-        options.required_contexts = options['required-contexts'].split(',');
+        options.required_contexts = requiredContexts.split(',');
       }
     }
 
-    if (options['transient-environment']) {
-      options.transient_environment = options['transient_environment'];
+    if (transientEnvironment) {
+      options.transient_environment = transientEnvironment;
     }
 
     // if payload is a json string evaluate it

--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -74,7 +74,7 @@ usage: --repo=foo *
        --ref=mybranch *
        --env=production
        --payload='{"hello": "world"}'
-       --auto-merge=true
+       --[no-]auto-merge
        --required-contexts=foo,bar,baz OR [] for no contexts
        --description='this is a description'
        --transient-environment=false
@@ -88,7 +88,7 @@ DeploymentCommand.flags = {
   'ref': flags.string({required: true, char: 'r', description: 'github ref,branch, or commit hash'}),
   'env': flags.string({char: 'e', description: 'the deployment environment (production, qa, test, development etc)'}),
   'payload': flags.string({char: 'p', description: 'a json string that contains any extra context you need for your deployment'}),
-  'auto-merge': flags.boolean({description: 'comma seperated string. auto merge the pr (see gh deployments api for reference)'}),
+  'auto-merge': flags.boolean({description: 'auto merge the default branch into pr (see gh deployments api for reference)', default: true, allowNo: true}),
   'required-contexts': flags.string({description: 'parameter allows you to specify a subset of contexts that must be success'}),
   'description': flags.string({char: 'd', description: 'description for your deployment'}),
   'transient-environment': flags.boolean({description: 'Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.'}),

--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -77,7 +77,7 @@ usage: --repo=foo *
        --[no-]auto-merge
        --required-contexts=foo,bar,baz OR [] for no contexts
        --description='this is a description'
-       --transient-environment=false
+       --transient-environment
 returns deployment id if successful
 `;
 

--- a/src/commands/pendingDeployments.js
+++ b/src/commands/pendingDeployments.js
@@ -64,7 +64,7 @@ DeploymentCommand.flags = {
   'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
   'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
   'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
-  'ref': flags.string({required: false, char: 'r', description: 'github ref,branch, or commit hash (defaults to master)'}),
+  'ref': flags.string({required: false, description: 'github ref,branch, or commit hash (defaults to master)'}),
   'env': flags.string({required: false, char: 'e', description: 'the environment to check deployments against\n defaults to all environments'}),
   'task': flags.string({required: false, description: 'The name of the task for the deployment'}),
   'sha': flags.string({required: false, description: 'The SHA recorded at creation time'}),

--- a/src/commands/pendingDeployments.js
+++ b/src/commands/pendingDeployments.js
@@ -24,7 +24,7 @@ import {getPendingDeployments} from '..';
 class DeploymentCommand extends Command {
   async run() {
     const {flags} = this.parse(DeploymentCommand);
-    const {repo, owner, token, ...rest} = flags;
+    const {repo, owner, token, env, ...rest} = flags;
     const options = {
       ...rest,
       ref: rest.ref || 'master',
@@ -32,16 +32,13 @@ class DeploymentCommand extends Command {
 
     // octokit will get deployments made to all environments if no environment is passed
     // we are just adding some more UX by allowing an 'all' environment to be pass
-    if (rest.env && rest.env.toLowerCase() !== 'all') {
-      options.environment = rest.env;
+    if (env && env.toLowerCase() !== 'all') {
+      options.environment = env;
     }
 
     try {
       const pendingDeploys = await getPendingDeployments(options, repo, owner, token);
-
-
       this.log(pendingDeploys, '\n');
-      // this.log(deployment.data.id);
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -33,18 +33,18 @@ const STATUSES = {
 class StatusCommand extends Command {
   async run() {
     const {flags} = this.parse(StatusCommand);
-    const {repo, owner, token, ...rest} = flags;
+    const {repo, owner, token, url, deployment, ...rest} = flags;
 
     const options = {
       ...rest,
     };
 
-    if (options['url']) {
-      options.log_url = options['url'];
+    if (url) {
+      options.log_url = url;
     }
 
-    if (options.deployment) {
-      options.deployment_id = options.deployment;
+    if (deployment) {
+      options.deployment_id = deployment;
     }
     try {
       await createDeploymentStatus(options, repo, owner, token);


### PR DESCRIPTION
I've gone through each of the CLI commands and sanitised the options passed to the Github API so that there aren't any duplicates or overriding of things.

I've also done a bit of a tidy up on some of the setting for the CLI flags themselves, tidying them up and updating the docs. The most notable are the changes to the boolean flags which currently weren't working as expected

Closes #9 