### PR TITLE
fix(cli): enables previews so all command line flags work

### DIFF
--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -20,6 +20,8 @@ Created by Patrick Simonian
 import {Command, flags} from '@oclif/command';
 import {createDeployment} from '../index';
 import {isString} from 'util';
+import {PREVIEWS} from '../constants';
+
 class DeploymentCommand extends Command {
   async run() {
     const {flags} = this.parse(DeploymentCommand);
@@ -36,7 +38,7 @@ class DeploymentCommand extends Command {
     const options = {
       ...rest,
       environment: env || rest.environment,
-      mediaType: {previews: ['ant-man']},
+      mediaType: {previews: [PREVIEWS.ANT_MAN]},
     };
 
     options.auto_merge = autoMerge;
@@ -77,8 +79,8 @@ DeploymentCommand.description = `Creates a github deployment
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar * 
-       --token=asdf1234 * 
+       --owner=bar *
+       --token=asdf1234 *
        --ref=mybranch *
        --env=production
        --payload='{"hello": "world"}'
@@ -92,14 +94,33 @@ returns deployment id if successful
 DeploymentCommand.flags = {
   'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
   'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
-  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
+  'token': flags.string({
+    required: true,
+    char: 't',
+    description: 'github access token (required correct permissions)',
+  }),
   'ref': flags.string({required: true, description: 'github ref,branch, or commit hash'}),
-  'env': flags.string({char: 'e', description: 'the deployment environment (production, qa, test, development etc)'}),
-  'payload': flags.string({char: 'p', description: 'a json string that contains any extra context you need for your deployment'}),
-  'auto-merge': flags.boolean({description: 'auto merge the default branch into pr (see gh deployments api for reference)', default: true, allowNo: true}),
-  'required-contexts': flags.string({description: 'parameter allows you to specify a subset of contexts that must be success'}),
+  'env': flags.string({
+    char: 'e',
+    description: 'the deployment environment (production, qa, test, development etc)',
+  }),
+  'payload': flags.string({
+    char: 'p',
+    description: 'a json string that contains any extra context you need for your deployment',
+  }),
+  'auto-merge': flags.boolean({
+    description: 'auto merge the default branch into pr (see gh deployments api for reference)',
+    default: true,
+    allowNo: true,
+  }),
+  'required-contexts': flags.string({
+    description: 'parameter allows you to specify a subset of contexts that must be success',
+  }),
   'description': flags.string({char: 'd', description: 'description for your deployment'}),
-  'transient-environment': flags.boolean({description: 'Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.'}),
+  'transient-environment': flags.boolean({
+    description:
+      'Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.',
+  }),
 };
 
 module.exports = DeploymentCommand;

--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -36,6 +36,7 @@ class DeploymentCommand extends Command {
     const options = {
       ...rest,
       environment: env || rest.environment,
+      mediaType: {previews: ['ant-man']},
     };
 
     options.auto_merge = autoMerge;

--- a/src/commands/deployment.js
+++ b/src/commands/deployment.js
@@ -79,8 +79,8 @@ DeploymentCommand.description = `Creates a github deployment
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar *
-       --token=asdf1234 *
+       --owner=bar * 
+       --token=asdf1234 * 
        --ref=mybranch *
        --env=production
        --payload='{"hello": "world"}'
@@ -94,33 +94,14 @@ returns deployment id if successful
 DeploymentCommand.flags = {
   'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
   'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
-  'token': flags.string({
-    required: true,
-    char: 't',
-    description: 'github access token (required correct permissions)',
-  }),
+  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
   'ref': flags.string({required: true, description: 'github ref,branch, or commit hash'}),
-  'env': flags.string({
-    char: 'e',
-    description: 'the deployment environment (production, qa, test, development etc)',
-  }),
-  'payload': flags.string({
-    char: 'p',
-    description: 'a json string that contains any extra context you need for your deployment',
-  }),
-  'auto-merge': flags.boolean({
-    description: 'auto merge the default branch into pr (see gh deployments api for reference)',
-    default: true,
-    allowNo: true,
-  }),
-  'required-contexts': flags.string({
-    description: 'parameter allows you to specify a subset of contexts that must be success',
-  }),
+  'env': flags.string({char: 'e', description: 'the deployment environment (production, qa, test, development etc)'}),
+  'payload': flags.string({char: 'p', description: 'a json string that contains any extra context you need for your deployment'}),
+  'auto-merge': flags.boolean({description: 'auto merge the default branch into pr (see gh deployments api for reference)', default: true, allowNo: true}),
+  'required-contexts': flags.string({description: 'parameter allows you to specify a subset of contexts that must be success'}),
   'description': flags.string({char: 'd', description: 'description for your deployment'}),
-  'transient-environment': flags.boolean({
-    description:
-      'Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.',
-  }),
+  'transient-environment': flags.boolean({description: 'Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future.'}),
 };
 
 module.exports = DeploymentCommand;

--- a/src/commands/pendingDeployments.js
+++ b/src/commands/pendingDeployments.js
@@ -54,8 +54,8 @@ DeploymentCommand.description = `Returns number of pending deployments made agai
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar *
-       --token=asdf1234 *
+       --owner=bar * 
+       --token=asdf1234 * 
        --ref=mybranch
        --env=production // defaults to all environments
        --task=foo
@@ -64,24 +64,13 @@ usage: --repo=foo *
 `;
 
 DeploymentCommand.flags = {
-  repo: flags.string({required: true, char: 'r', description: 'github repo name'}),
-  owner: flags.string({required: true, char: 'o', description: 'github owner name'}),
-  token: flags.string({
-    required: true,
-    char: 't',
-    description: 'github access token (required correct permissions)',
-  }),
-  ref: flags.string({
-    required: false,
-    description: 'github ref,branch, or commit hash (defaults to master)',
-  }),
-  env: flags.string({
-    required: false,
-    char: 'e',
-    description: 'the environment to check deployments against\n defaults to all environments',
-  }),
-  task: flags.string({required: false, description: 'The name of the task for the deployment'}),
-  sha: flags.string({required: false, description: 'The SHA recorded at creation time'}),
+  'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
+  'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
+  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
+  'ref': flags.string({required: false, description: 'github ref,branch, or commit hash (defaults to master)'}),
+  'env': flags.string({required: false, char: 'e', description: 'the environment to check deployments against\n defaults to all environments'}),
+  'task': flags.string({required: false, description: 'The name of the task for the deployment'}),
+  'sha': flags.string({required: false, description: 'The SHA recorded at creation time'}),
 };
 
 module.exports = DeploymentCommand;

--- a/src/commands/pendingDeployments.js
+++ b/src/commands/pendingDeployments.js
@@ -19,7 +19,7 @@ Created by Patrick Simonian
 /* eslint-disable require-jsdoc */
 import {Command, flags} from '@oclif/command';
 import {getPendingDeployments} from '..';
-
+import {PREVIEWS} from '../constants';
 
 class DeploymentCommand extends Command {
   async run() {
@@ -29,7 +29,7 @@ class DeploymentCommand extends Command {
       ...rest,
       ref: rest.ref || 'master',
       mediaType: {
-        previews: ['ant-man', 'flash'],
+        previews: [PREVIEWS.ANT_MAN, PREVIEWS.FLASH],
       },
     };
 
@@ -54,8 +54,8 @@ DeploymentCommand.description = `Returns number of pending deployments made agai
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar * 
-       --token=asdf1234 * 
+       --owner=bar *
+       --token=asdf1234 *
        --ref=mybranch
        --env=production // defaults to all environments
        --task=foo
@@ -64,13 +64,24 @@ usage: --repo=foo *
 `;
 
 DeploymentCommand.flags = {
-  'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
-  'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
-  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
-  'ref': flags.string({required: false, description: 'github ref,branch, or commit hash (defaults to master)'}),
-  'env': flags.string({required: false, char: 'e', description: 'the environment to check deployments against\n defaults to all environments'}),
-  'task': flags.string({required: false, description: 'The name of the task for the deployment'}),
-  'sha': flags.string({required: false, description: 'The SHA recorded at creation time'}),
+  repo: flags.string({required: true, char: 'r', description: 'github repo name'}),
+  owner: flags.string({required: true, char: 'o', description: 'github owner name'}),
+  token: flags.string({
+    required: true,
+    char: 't',
+    description: 'github access token (required correct permissions)',
+  }),
+  ref: flags.string({
+    required: false,
+    description: 'github ref,branch, or commit hash (defaults to master)',
+  }),
+  env: flags.string({
+    required: false,
+    char: 'e',
+    description: 'the environment to check deployments against\n defaults to all environments',
+  }),
+  task: flags.string({required: false, description: 'The name of the task for the deployment'}),
+  sha: flags.string({required: false, description: 'The SHA recorded at creation time'}),
 };
 
 module.exports = DeploymentCommand;

--- a/src/commands/pendingDeployments.js
+++ b/src/commands/pendingDeployments.js
@@ -28,6 +28,9 @@ class DeploymentCommand extends Command {
     const options = {
       ...rest,
       ref: rest.ref || 'master',
+      mediaType: {
+        previews: ['ant-man', 'flash'],
+      },
     };
 
     // octokit will get deployments made to all environments if no environment is passed

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -63,8 +63,8 @@ StatusCommand.description = `Creates a github deployment status
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar *
-       --token=asdf1234 *
+       --owner=bar * 
+       --token=asdf1234 * 
        --state=queued *
        --deployment=12354123
        --url=https://path-to-my-env.com
@@ -72,25 +72,13 @@ returns status id if successful
 `;
 
 StatusCommand.flags = {
-  repo: flags.string({required: true, char: 'r', description: 'github repo name'}),
-  owner: flags.string({required: true, char: 'o', description: 'github owner name'}),
-  token: flags.string({
-    required: true,
-    char: 't',
-    description: 'github access token (required correct permissions)',
-  }),
-  deployment: flags.string({required: true, description: 'github deployment id'}),
-  description: flags.string({char: 'd', description: 'description for your deployment status'}),
-  state: flags.string({
-    required: true,
-    char: 's',
-    description: 'the deployments state',
-    options: Object.keys(STATUSES),
-  }),
-  url: flags.string({
-    char: 'u',
-    description: 'The environment url (translates to log_url in the deployment status call)',
-  }),
+  'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
+  'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
+  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
+  'deployment': flags.string({required: true, description: 'github deployment id'}),
+  'description': flags.string({char: 'd', description: 'description for your deployment status'}),
+  'state': flags.string({required: true, char: 's', description: 'the deployments state', options: Object.keys(STATUSES)}),
+  'url': flags.string({char: 'u', description: 'The environment url (translates to log_url in the deployment status call)'}),
 };
 
 module.exports = StatusCommand;

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -19,6 +19,7 @@ Created by Patrick Simonian
 /* eslint-disable require-jsdoc */
 import {Command, flags} from '@oclif/command';
 import {createDeploymentStatus} from '../index';
+import {PREVIEWS} from '../constants';
 
 const STATUSES = {
   error: 'error',
@@ -37,7 +38,7 @@ class StatusCommand extends Command {
 
     const options = {
       ...rest,
-      mediaType: {previews: ['ant-man', 'flash']},
+      mediaType: {previews: [PREVIEWS.ANT_MAN, PREVIEWS.FLASH]},
     };
 
     if (url) {
@@ -62,8 +63,8 @@ StatusCommand.description = `Creates a github deployment status
 ...
 * = required
 usage: --repo=foo *
-       --owner=bar * 
-       --token=asdf1234 * 
+       --owner=bar *
+       --token=asdf1234 *
        --state=queued *
        --deployment=12354123
        --url=https://path-to-my-env.com
@@ -71,13 +72,25 @@ returns status id if successful
 `;
 
 StatusCommand.flags = {
-  'repo': flags.string({required: true, char: 'r', description: 'github repo name'}),
-  'owner': flags.string({required: true, char: 'o', description: 'github owner name'}),
-  'token': flags.string({required: true, char: 't', description: 'github access token (required correct permissions)'}),
-  'deployment': flags.string({required: true, description: 'github deployment id'}),
-  'description': flags.string({char: 'd', description: 'description for your deployment status'}),
-  'state': flags.string({required: true, char: 's', description: 'the deployments state', options: Object.keys(STATUSES)}),
-  'url': flags.string({char: 'u', description: 'The environment url (translates to log_url in the deployment status call)'}),
+  repo: flags.string({required: true, char: 'r', description: 'github repo name'}),
+  owner: flags.string({required: true, char: 'o', description: 'github owner name'}),
+  token: flags.string({
+    required: true,
+    char: 't',
+    description: 'github access token (required correct permissions)',
+  }),
+  deployment: flags.string({required: true, description: 'github deployment id'}),
+  description: flags.string({char: 'd', description: 'description for your deployment status'}),
+  state: flags.string({
+    required: true,
+    char: 's',
+    description: 'the deployments state',
+    options: Object.keys(STATUSES),
+  }),
+  url: flags.string({
+    char: 'u',
+    description: 'The environment url (translates to log_url in the deployment status call)',
+  }),
 };
 
 module.exports = StatusCommand;

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -37,6 +37,7 @@ class StatusCommand extends Command {
 
     const options = {
       ...rest,
+      mediaType: {previews: ['ant-man', 'flash']},
     };
 
     if (url) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,3 @@
-
 export const STATUS_STATES = {
   PENDING: 'pending',
   SUCCESS: 'success',
@@ -6,3 +5,7 @@ export const STATUS_STATES = {
   ERROR: 'error',
 };
 
+export const PREVIEWS = {
+  ANT_MAN: 'ant-man',
+  FLASH: 'flash',
+};


### PR DESCRIPTION
Currently some flags (such as `--url` in `status`) require the preview version of the API. See https://octokit.github.io/rest.js/#previews

I missed this during the last round of changes